### PR TITLE
chore : cors 설정, 라우팅 규칙 추가

### DIFF
--- a/src/main/java/site/iotify/gatewayservice/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/site/iotify/gatewayservice/filter/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package site.iotify.gatewayservice.fiter;
+package site.iotify.gatewayservice.filter;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,10 +11,17 @@ spring:
             - Path=/user/**
           uri: http://localhost:8092
           filters:
-            - RewritePath=/user/(?<segment>.*), /$\{segment}
+            - RewritePath=/user/(?<segment>.*), /${segment}
             - name: JwtAuthenticationFilter
               args:
                 secretKey: ${jwt.secret.key}
+
+        - id: user-service-filter-excluded
+          predicates:
+            - Path=/users/**
+          uri: http://localhost:8092
+          filters:
+            - RewritePath=/users/(?<segment>.*), /${segment}
 
         - id: token-service
           predicates:
@@ -22,3 +29,10 @@ spring:
           uri: http://localhost:8091
           filters:
             - RewritePath=/token/(?<segment>.*), /$\{segment}
+
+        - id: device-service
+          predicates:
+            - Path=/device/**
+          uri: http://localhost:8093
+          filters:
+            - RewritePath=/device/(?<segment>.*), /$\{segment}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,9 +16,23 @@ spring:
               args:
                 secretKey: ${jwt.secret.key}
 
+        - id: user-service-filter-excluded
+          predicates:
+            - Path=/users/**
+          uri: http://localhost:8092
+          filters:
+            - RewritePath=/users/(?<segment>.*), /${segment}
+
         - id: token-service
           predicates:
             - Path=/token/**
           uri: http://token-service:8091
           filters:
             - RewritePath=/token/(?<segment>.*), /$\{segment}
+
+        - id: device-service
+          predicates:
+            - Path=/device/**
+          uri: http://localhost:8093
+          filters:
+            - RewritePath=/device/(?<segment>.*), /$\{segment}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,24 @@ spring:
     name: gatewayservice
   profiles:
     active: dev
+  cloud:
+    gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowed-origin-patterns:
+              - "*"
+            allowed-methods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
+            allow-credentials:
+              true
+            allowed-headers:
+              - "*"
+            exposed-headers:
+              - "*"
 
 logging:
   level:


### PR DESCRIPTION
front-service -> 게이트웨이 -> user-service로 보내지는 요청중에서
인증이 필요 없는 요청은 prefix로 `users/` 를 붙여서 보내면
게이트웨이 서비스가 prefix를 제거하고 `user-service`로 라우팅 해주도록 설정했음

---

front-service -> 게이트웨이 -> device-service로 보내지는 요청은
게이트웨이 서비스가 prefix를 제거하고 `device-service`로 라우팅 해주도록 설정했음

우선은 device-service로 라우팅할 때 인증필터 동작 안 하도록 설정해씀

---

cors는 일단 모두 허용하도록 설정했음